### PR TITLE
Make macros for encode and decode

### DIFF
--- a/src/commit_comments/types.rs
+++ b/src/commit_comments/types.rs
@@ -61,33 +61,12 @@ mod types {
     Updated
   }
 
-  impl Decodable for PullRequestCommentSortable {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PullRequestCommentSortable, D::Error> {
-      d
-        .read_str()
-        .and_then(|state_str| {
-          match state_str.as_ref() {
-            "created" => Ok(PullRequestCommentSortable::Created),
-            "updated" => Ok(PullRequestCommentSortable::Updated),
-            _ => {
-              let err_str = "no matching pull request comment sortable for ".to_owned() + &state_str;
-              Err(d.error(&err_str))
-            }
-          }
-        })
-    }
-  }
-
-  impl Encodable for PullRequestCommentSortable {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-      let state_str =
-        match *self {
-          PullRequestCommentSortable::Created => "created",
-          PullRequestCommentSortable::Updated => "updated"
-        };
-      s.emit_str(state_str)
-    }
-  }
+  custom_enum_decode_encode!(
+    PullRequestCommentSortable [
+      "created" <=> [PullRequestCommentSortable::Created],
+      "updated" <=> [PullRequestCommentSortable::Updated],
+    ]
+  );
 
   #[derive(RustcDecodable, RustcEncodable, Debug)]
   pub struct CreateComment {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,12 +6,15 @@ extern crate rustc_serialize;
 #[macro_use(expect)]
 extern crate expectest;
 
+#[macro_use]
+mod types;
+
 mod commits;
 mod github_client;
 mod pull_requests;
 mod commit_comments;
 mod repos;
-mod types;
+
 mod users;
 
 pub use github_client::GithubClient;

--- a/src/pull_requests/types.rs
+++ b/src/pull_requests/types.rs
@@ -50,33 +50,12 @@ mod types {
     Closed
   }
 
-  impl Decodable for PullRequestState {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PullRequestState, D::Error> {
-      d
-        .read_str()
-        .and_then(|state_str| {
-          match state_str.as_ref() {
-            "open" => Ok(PullRequestState::Open),
-            "closed" => Ok(PullRequestState::Closed),
-            _ => {
-              let err_str = "no matching pull request state for ".to_owned() + &state_str;
-              Err(d.error(&err_str))
-            }
-          }
-        })
-    }
-  }
-
-  impl Encodable for PullRequestState {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-      let state_str =
-        match *self {
-          PullRequestState::Open => "open",
-          PullRequestState::Closed => "closed"
-        };
-      s.emit_str(state_str)
-    }
-  }
+  custom_enum_decode_encode!(
+    PullRequestState [
+      "open" <=> [PullRequestState::Open],
+      "closed" <=> [PullRequestState::Closed],
+    ]
+  );
 
   #[derive(Debug)]
   pub enum PullRequestStateQuery {
@@ -85,35 +64,13 @@ mod types {
     All
   }
 
-  impl Decodable for PullRequestStateQuery {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PullRequestStateQuery, D::Error> {
-      d
-        .read_str()
-        .and_then(|state_str| {
-          match state_str.as_ref() {
-            "open" => Ok(PullRequestStateQuery::Open),
-            "closed" => Ok(PullRequestStateQuery::Closed),
-            "all" => Ok(PullRequestStateQuery::All),
-            _ => {
-              let err_str = "no matching pull request state query for ".to_owned() + &state_str;
-              Err(d.error(&err_str))
-            }
-          }
-        })
-    }
-  }
-
-  impl Encodable for PullRequestStateQuery {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-      let state_str =
-        match *self {
-          PullRequestStateQuery::Open => "open",
-          PullRequestStateQuery::Closed => "closed",
-          PullRequestStateQuery::All => "all"
-        };
-      s.emit_str(state_str)
-    }
-  }
+  custom_enum_decode_encode!(
+    PullRequestStateQuery [
+      "open" <=> [PullRequestStateQuery::Open],
+      "closed" <=> [PullRequestStateQuery::Closed],
+      "all" <=> [PullRequestStateQuery::All],
+    ]
+  );
 
   #[derive(Debug)]
   pub enum PullRequestSortables {
@@ -123,37 +80,14 @@ mod types {
     LongRunning,
   }
 
-  impl Decodable for PullRequestSortables {
-    fn decode<D: Decoder>(d: &mut D) -> Result<PullRequestSortables, D::Error> {
-      d
-        .read_str()
-        .and_then(|state_str| {
-          match state_str.as_ref() {
-            "created" => Ok(PullRequestSortables::CreatedAt),
-            "updated" => Ok(PullRequestSortables::UpdatedAt),
-            "popularity" => Ok(PullRequestSortables::CommentCount),
-            "long-running" => Ok(PullRequestSortables::LongRunning),
-            _ => {
-              let err_str = "no matching sort direction for ".to_owned() + &state_str;
-              Err(d.error(&err_str))
-            }
-          }
-        })
-    }
-  }
-
-  impl Encodable for PullRequestSortables {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-      let state_str =
-        match *self {
-          PullRequestSortables::CreatedAt => "created",
-          PullRequestSortables::UpdatedAt => "updated",
-          PullRequestSortables::CommentCount => "popularity",
-          PullRequestSortables::LongRunning => "long-running",
-        };
-      s.emit_str(state_str)
-    }
-  }
+  custom_enum_decode_encode!(
+    PullRequestSortables [
+      "created" <=> [PullRequestSortables::CreatedAt],
+      "updated" <=> [PullRequestSortables::UpdatedAt],
+      "popularity" <=> [PullRequestSortables::CommentCount],
+      "long-running" <=> [PullRequestSortables::LongRunning],
+    ]
+  );
 
   #[derive(RustcEncodable, RustcDecodable, Debug)]
   pub struct PullRequestQuery {

--- a/src/repos/types.rs
+++ b/src/repos/types.rs
@@ -158,36 +158,13 @@ mod types {
     Private,
     All
   }
-
-  impl Decodable for RepoVisibility {
-    fn decode<D: Decoder>(d: &mut D) -> Result<RepoVisibility, D::Error> {
-      d
-        .read_str()
-        .and_then(|state_str| {
-          match state_str.as_ref() {
-            "public" => Ok(RepoVisibility::Public),
-            "private" => Ok(RepoVisibility::Private),
-            "all" => Ok(RepoVisibility::All),
-            _ => {
-              let err_str = "no matching repo visibility for ".to_owned() + &state_str;
-              Err(d.error(&err_str))
-            }
-          }
-        })
-    }
-  }
-
-  impl Encodable for RepoVisibility {
-    fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-      let state_str =
-        match *self {
-          RepoVisibility::Public => "public",
-          RepoVisibility::Private => "private",
-          RepoVisibility::All => "all"
-        };
-      s.emit_str(state_str)
-    }
-  }
+  custom_enum_decode_encode!(
+    RepoVisibility [
+      "public" <=> [RepoVisibility::Public],
+      "private" <=> [RepoVisibility::Private],
+      "all" <=> [RepoVisibility::All],
+    ]
+  );
 
   // TODO: Make this a proper product type
   pub type RepoAffiliations = String;
@@ -199,53 +176,6 @@ mod types {
     FullName,
   }
 
-  macro_rules! custom_enum_encode {
-    (
-      $enum_ty:ty [ $( $an_enum:pat => $string:expr, )* ]
-    ) => {
-      impl Encodable for $enum_ty {
-        fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
-          let state_str =
-            match *self {
-              $($an_enum => $string,)*
-            };
-          s.emit_str(state_str)
-        }
-      }
-    }
-  }
-
-  macro_rules! custom_enum_decode {
-    (
-      $enum_ty:ty [ $( $string:expr => $an_enum:expr, )* ]
-    ) => {
-      impl Decodable for $enum_ty {
-        fn decode<D: Decoder>(d: &mut D) -> Result<$enum_ty, D::Error> {
-          d
-            .read_str()
-            .and_then(|state_str| {
-              match state_str.as_ref() {
-                $($string => Ok($an_enum),)*
-                _ => {
-                  let err_str = "no matching item for ".to_owned() + &state_str;
-                  Err(d.error(&err_str))
-                }
-              }
-            })
-        }
-      }
-    }
-  }
-
-  macro_rules! custom_enum_decode_encode {
-    (
-      $enum_ty:ty [ $($string:tt <=> [$($an_enum:tt)*],)* ]
-    ) => {
-      custom_enum_decode!($enum_ty [ $( $string => $($an_enum)*, )+ ]);
-      custom_enum_encode!($enum_ty [ $( $($an_enum)* => $string, )+ ]);
-    }
-  }
-
   custom_enum_decode_encode!(
     RepoSortables [
       "updated" <=> [RepoSortables::Updated],
@@ -253,8 +183,6 @@ mod types {
       "full_name" <=> [RepoSortables::FullName],
     ]
   );
-
-
 
   #[derive(RustcEncodable, Debug)]
   pub struct CreateRepository {


### PR DESCRIPTION
There was a lot of copy and paste when the Github api took a lowercase string, but I wanted the enum to be uppercase. Or in other circumstances, their string they expected wasn't as clear as it could be. This macro should clean up that noise.
